### PR TITLE
Check CC environment variable in build.lua

### DIFF
--- a/test/build.lua
+++ b/test/build.lua
@@ -2,7 +2,7 @@
 -- identify the compiler?
 -- locate dependencies?
 local function foo()
-	return "cc"
+	return os.getenv("CC") or "cc"
 end
 
 return {


### PR DESCRIPTION
...so that you can `CC=clang`, for example.

From <https://discord.com/channels/1005603569187160125/1140732081568223272/1276132440280272916>.

*No I did not name the branch "I see you see my C compiler". Totally.*